### PR TITLE
Removes SwiftBaseX and CryptoSwift dependencies (Base58 algorithm imp…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,82 @@
+
+# Created by https://www.gitignore.io/api/swift,xcode
+
+### Swift ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+.build/
+
+# CocoaPods - Refactored to standalone file
+
+# Carthage - Refactored to standalone file
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo. Instead, use fastlane to re-generate the
+# screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+
+### Xcode ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## Build generated
+
+## Various settings
+
+## Other
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+/*.gcno
+
+# End of https://www.gitignore.io/api/swift,xcode
+
+

--- a/CommonCrypto/_CommonCrypto.h
+++ b/CommonCrypto/_CommonCrypto.h
@@ -1,0 +1,15 @@
+//
+//  _CommonCrypto.h
+//  NeoSwift
+//
+//  Created by Luís Silva on 14/09/17.
+//  Copyright © 2017 drei. All rights reserved.
+//
+
+#ifndef _CommonCrypto_h
+#define _CommonCrypto_h
+
+#include <CommonCrypto/CommonCrypto.h>
+
+
+#endif /* _CommonCrypto_h */

--- a/CommonCrypto/module.modulemap
+++ b/CommonCrypto/module.modulemap
@@ -1,0 +1,4 @@
+module CommonCrypto [system] {
+    header "_CommonCrypto.h"
+    export *
+}

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,3 +1,4 @@
 Andrei Terentiev @saltyskip
 Apisit Toompakadee @apisit
 Juame Navas @jaumevn
+Luís Silva @lm2s

--- a/NeoSwift.xcodeproj/project.pbxproj
+++ b/NeoSwift.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		6E013E301F695337006EE34F /* AccountState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E013E2F1F695337006EE34F /* AccountState.swift */; };
 		6E0F80C71F67F8E90068CEF8 /* TransactionAttritbute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E0F80C61F67F8E90068CEF8 /* TransactionAttritbute.swift */; };
 		753518DE1F6E365500453245 /* TransactionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753518DD1F6E365500453245 /* TransactionHistory.swift */; };
-		75631AD31F4FB8D5008546CF /* SwiftBaseX.framework.dSYM in CopyFiles */ = {isa = PBXBuildFile; fileRef = 75631AD21F4FB8D5008546CF /* SwiftBaseX.framework.dSYM */; };
 		75631AD51F5013BC008546CF /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75631AD41F5013BC008546CF /* Account.swift */; };
 		75631ADB1F5162F6008546CF /* AssetIdConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75631ADA1F5162F6008546CF /* AssetIdConstants.swift */; };
 		75631ADD1F516D94008546CF /* Balance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75631ADC1F516D94008546CF /* Balance.swift */; };
@@ -25,14 +24,12 @@
 		75CDAE2A1F48680500B05C51 /* NeoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75CDAE091F47F90800B05C51 /* NeoSwift.framework */; };
 		75CDAE311F48750E00B05C51 /* NeoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75CDAE301F48750E00B05C51 /* NeoClient.swift */; };
 		75DBF7281F5D7714006C87F3 /* Neowallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75DBF7271F5D7714006C87F3 /* Neowallet.framework */; };
-		75E8E4991F4DBD5300DBCD8E /* SwiftBaseX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75E8E4981F4DBD5300DBCD8E /* SwiftBaseX.framework */; };
 		75E8E49C1F4DBFAC00DBCD8E /* WIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75E8E49B1F4DBFAC00DBCD8E /* WIF.swift */; };
-		75E8E4A21F4EAA6700DBCD8E /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75E8E4A11F4EAA6600DBCD8E /* CryptoSwift.framework */; };
-		75E8E4A41F4EAB2E00DBCD8E /* CryptoSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75E8E4A11F4EAA6600DBCD8E /* CryptoSwift.framework */; };
-		75E8E4A51F4EAB2E00DBCD8E /* SwiftBaseX.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75E8E4981F4DBD5300DBCD8E /* SwiftBaseX.framework */; };
 		75E8E4A61F4EAB5800DBCD8E /* NeoSwift.framework in Resources */ = {isa = PBXBuildFile; fileRef = 75CDAE091F47F90800B05C51 /* NeoSwift.framework */; };
-		75E8E4A71F4EABC600DBCD8E /* CryptoSwift.framework in Resources */ = {isa = PBXBuildFile; fileRef = 75E8E4A11F4EAA6600DBCD8E /* CryptoSwift.framework */; };
-		75E8E4A81F4EABC600DBCD8E /* SwiftBaseX.framework in Resources */ = {isa = PBXBuildFile; fileRef = 75E8E4981F4DBD5300DBCD8E /* SwiftBaseX.framework */; };
+		F31C7F0E1F6E759D0075688D /* Base58.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C7F0B1F6E75530075688D /* Base58.swift */; };
+		F31C7F0F1F6E759D0075688D /* Data+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C7F0C1F6E75530075688D /* Data+Util.swift */; };
+		F31C7F101F6E759D0075688D /* SHA256.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C7F0D1F6E75530075688D /* SHA256.swift */; };
+		F31C7FA21F6E83D70075688D /* NeoCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F31C7FA11F6E83D70075688D /* NeoCryptoTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -52,7 +49,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 16;
 			files = (
-				75631AD31F4FB8D5008546CF /* SwiftBaseX.framework.dSYM in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -63,7 +59,6 @@
 		6E013E2F1F695337006EE34F /* AccountState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountState.swift; sourceTree = "<group>"; };
 		6E0F80C61F67F8E90068CEF8 /* TransactionAttritbute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionAttritbute.swift; sourceTree = "<group>"; };
 		753518DD1F6E365500453245 /* TransactionHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionHistory.swift; sourceTree = "<group>"; };
-		75631AD21F4FB8D5008546CF /* SwiftBaseX.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; name = SwiftBaseX.framework.dSYM; path = Carthage/Build/iOS/SwiftBaseX.framework.dSYM; sourceTree = "<group>"; };
 		75631AD41F5013BC008546CF /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
 		75631ADA1F5162F6008546CF /* AssetIdConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIdConstants.swift; sourceTree = "<group>"; };
 		75631ADC1F516D94008546CF /* Balance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Balance.swift; sourceTree = "<group>"; };
@@ -80,9 +75,11 @@
 		75CDAE291F48680500B05C51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		75CDAE301F48750E00B05C51 /* NeoClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NeoClient.swift; path = NeoSwift/NeoClient.swift; sourceTree = SOURCE_ROOT; };
 		75DBF7271F5D7714006C87F3 /* Neowallet.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Neowallet.framework; sourceTree = "<group>"; };
-		75E8E4981F4DBD5300DBCD8E /* SwiftBaseX.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftBaseX.framework; path = Carthage/Build/iOS/SwiftBaseX.framework; sourceTree = "<group>"; };
 		75E8E49B1F4DBFAC00DBCD8E /* WIF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIF.swift; sourceTree = "<group>"; };
-		75E8E4A11F4EAA6600DBCD8E /* CryptoSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoSwift.framework; path = Carthage/Build/iOS/CryptoSwift.framework; sourceTree = "<group>"; };
+		F31C7F0B1F6E75530075688D /* Base58.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base58.swift; sourceTree = "<group>"; };
+		F31C7F0C1F6E75530075688D /* Data+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Util.swift"; sourceTree = "<group>"; };
+		F31C7F0D1F6E75530075688D /* SHA256.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA256.swift; sourceTree = "<group>"; };
+		F31C7FA11F6E83D70075688D /* NeoCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NeoCryptoTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -90,9 +87,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75E8E4A21F4EAA6700DBCD8E /* CryptoSwift.framework in Frameworks */,
 				75DBF7281F5D7714006C87F3 /* Neowallet.framework in Frameworks */,
-				75E8E4991F4DBD5300DBCD8E /* SwiftBaseX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -101,8 +96,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				75CDAE2A1F48680500B05C51 /* NeoSwift.framework in Frameworks */,
-				75E8E4A41F4EAB2E00DBCD8E /* CryptoSwift.framework in Frameworks */,
-				75E8E4A51F4EAB2E00DBCD8E /* SwiftBaseX.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,7 +105,6 @@
 		75CDADFF1F47F90800B05C51 = {
 			isa = PBXGroup;
 			children = (
-				75631AD21F4FB8D5008546CF /* SwiftBaseX.framework.dSYM */,
 				75CDAE0B1F47F90800B05C51 /* NeoSwift */,
 				75CDAE261F48680500B05C51 /* NeoSwiftTests */,
 				75CDAE0A1F47F90800B05C51 /* Products */,
@@ -137,6 +129,7 @@
 				75631ADA1F5162F6008546CF /* AssetIdConstants.swift */,
 				75E8E49B1F4DBFAC00DBCD8E /* WIF.swift */,
 				75CDAE141F47F92400B05C51 /* Models */,
+				F31C7F0A1F6E75530075688D /* Util */,
 				75CDAE0D1F47F90800B05C51 /* Info.plist */,
 			);
 			path = NeoSwift;
@@ -164,6 +157,7 @@
 			children = (
 				75CDAE271F48680500B05C51 /* NeoSwiftTests.swift */,
 				7575ADF51F602C590077007B /* NeoWalletTests.swift */,
+				F31C7FA11F6E83D70075688D /* NeoCryptoTests.swift */,
 				75CDAE291F48680500B05C51 /* Info.plist */,
 			);
 			path = NeoSwiftTests;
@@ -173,10 +167,18 @@
 			isa = PBXGroup;
 			children = (
 				75DBF7271F5D7714006C87F3 /* Neowallet.framework */,
-				75E8E4A11F4EAA6600DBCD8E /* CryptoSwift.framework */,
-				75E8E4981F4DBD5300DBCD8E /* SwiftBaseX.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F31C7F0A1F6E75530075688D /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				F31C7F0B1F6E75530075688D /* Base58.swift */,
+				F31C7F0C1F6E75530075688D /* Data+Util.swift */,
+				F31C7F0D1F6E75530075688D /* SHA256.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -200,7 +202,6 @@
 				75CDAE051F47F90800B05C51 /* Frameworks */,
 				75CDAE061F47F90800B05C51 /* Headers */,
 				75CDAE071F47F90800B05C51 /* Resources */,
-				75E8E49A1F4DBDA300DBCD8E /* ShellScript */,
 				75631AD11F4FB8B6008546CF /* CopyFiles */,
 			);
 			buildRules = (
@@ -219,7 +220,6 @@
 				75CDAE211F48680500B05C51 /* Sources */,
 				75CDAE221F48680500B05C51 /* Frameworks */,
 				75CDAE231F48680500B05C51 /* Resources */,
-				75E8E4A31F4EAAA400DBCD8E /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -280,52 +280,20 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				75E8E4A71F4EABC600DBCD8E /* CryptoSwift.framework in Resources */,
-				75E8E4A81F4EABC600DBCD8E /* SwiftBaseX.framework in Resources */,
 				75E8E4A61F4EAB5800DBCD8E /* NeoSwift.framework in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		75E8E49A1F4DBDA300DBCD8E /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/SwiftBaseX.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/CryptoSwift.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-		75E8E4A31F4EAAA400DBCD8E /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/SwiftBaseX.framework",
-				"$(SRCROOT)/Carthage/Build/iOS/CryptoSwift.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
 		75CDAE041F47F90800B05C51 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F31C7F0E1F6E759D0075688D /* Base58.swift in Sources */,
+				F31C7F0F1F6E759D0075688D /* Data+Util.swift in Sources */,
+				F31C7F101F6E759D0075688D /* SHA256.swift in Sources */,
 				75CDAE181F47FFDA00B05C51 /* Script.swift in Sources */,
 				75E8E49C1F4DBFAC00DBCD8E /* WIF.swift in Sources */,
 				6E013E301F695337006EE34F /* AccountState.swift in Sources */,
@@ -347,6 +315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F31C7FA21F6E83D70075688D /* NeoCryptoTests.swift in Sources */,
 				75CDAE281F48680500B05C51 /* NeoSwiftTests.swift in Sources */,
 				7575ADF61F602C590077007B /* NeoWalletTests.swift in Sources */,
 			);
@@ -488,7 +457,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/NeoSwift",
 					"$(PROJECT_DIR)",
 				);
@@ -498,6 +466,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = drei.NeoSwift;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/CommonCrypto";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -516,7 +485,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/NeoSwift",
 					"$(PROJECT_DIR)",
 				);
@@ -526,6 +494,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = drei.NeoSwift;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/CommonCrypto";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -535,14 +504,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = 5C4B7MW8PU;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NeoSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = drei.NeoSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/CommonCrypto";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -552,14 +519,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				DEVELOPMENT_TEAM = 5C4B7MW8PU;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = NeoSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = drei.NeoSwiftTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/CommonCrypto";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/NeoSwift/Account.swift
+++ b/NeoSwift/Account.swift
@@ -18,11 +18,11 @@ public class Account {
     public var hashedSignature: Data
     
     lazy var publicKeyString : String = {
-        return publicKey.bytes.toHexString()
+        return publicKey.fullHexString
     }()
     
     lazy var privateKeyString : String = {
-        return privateKey.bytes.toHexString()
+        return privateKey.fullHexString
     }()
     
     public init?(wif: String) {
@@ -56,7 +56,7 @@ public class Account {
         }
         
         var error: NSError?
-        guard let wallet = GoNeowalletGeneratePublicKeyFromPrivateKey(pkeyData.toHexString(), &error) else { return nil }
+        guard let wallet = GoNeowalletGeneratePublicKeyFromPrivateKey(pkeyData.fullHexString, &error) else { return nil }
         self.wif = wallet.wif()
         self.publicKey = wallet.publicKey()
         self.privateKey = pkeyData
@@ -207,7 +207,7 @@ public class Account {
         let inputData = getInputsNecessaryToSendAsset(asset: asset, amount: amount, assets: assets)
         let rawTransaction = packRawTransactionBytes(asset: asset, with: inputData.payload!, runningAmount: inputData.totalAmount!,
                                                      toSendAmount: amount, toAddress: toAddress, attributes: attributes)
-        let signatureData = GoNeowalletSign(rawTransaction, privateKey.toHexString(), &error)
+        let signatureData = GoNeowalletSign(rawTransaction, privateKey.fullHexString, &error)
         let finalPayload = concatenatePayloadData(txData: rawTransaction, signatureData: signatureData!)
         return finalPayload
         

--- a/NeoSwift/Models/AccountState.swift
+++ b/NeoSwift/Models/AccountState.swift
@@ -9,11 +9,11 @@
 import UIKit
 
 public struct AccountState: Codable {
-    var version: Int
-    var scriptHash: String
-    var frozen: Bool
+    public var version: Int
+    public var scriptHash: String
+    public var frozen: Bool
     //var votes: it's there in JSON response but I don't know what type is it.
-    var balances: [Asset]
+    public var balances: [Asset]
     
     enum CodingKeys : String, CodingKey {
         case version = "version"

--- a/NeoSwift/Models/Asset.swift
+++ b/NeoSwift/Models/Asset.swift
@@ -10,8 +10,8 @@ import UIKit
 
 public struct AssetName: Codable {
     
-    var languageCode: String
-    var name: String
+    public var languageCode: String
+    public var name: String
     
     enum CodingKeys : String, CodingKey {
         case languageCode = "lang"
@@ -33,17 +33,17 @@ public struct AssetName: Codable {
 
 public struct AssetState: Codable {
 
-    var version: Int
-    var id: String
-    var type: String
-    var names: [AssetName]
-    var amount: String
-    var available: String
-    var precision: Int
-    var admin: String
-    var issuer: String
-    var expiration: Int
-    var frozen: Bool
+    public var version: Int
+    public var id: String
+    public var type: String
+    public var names: [AssetName]
+    public var amount: String
+    public var available: String
+    public var precision: Int
+    public var admin: String
+    public var issuer: String
+    public var expiration: Int
+    public var frozen: Bool
     
     enum CodingKeys : String, CodingKey {
         case version = "version"
@@ -91,8 +91,8 @@ public struct AssetState: Codable {
 }
 
 public struct Asset: Codable {
-     var id: String
-     var value: String
+    public var id: String
+    public var value: String
     
     enum CodingKeys : String, CodingKey {
         case id = "asset"

--- a/NeoSwift/Models/Balance.swift
+++ b/NeoSwift/Models/Balance.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public struct Unspent: Codable {
-    var index: Int
-    var txId: String
-    var value: Double
+    public var index: Int
+    public var txId: String
+    public var value: Double
     
     enum CodingKeys: String, CodingKey {
         case index = "index"
@@ -35,8 +35,8 @@ public struct Unspent: Codable {
 }
 
 public struct Gas: Codable {
-    var balance: Double
-    var unspent: [Unspent]
+    public var balance: Double
+    public var unspent: [Unspent]
     
     enum CodingKeys: String, CodingKey {
         case balance = "balance"
@@ -57,8 +57,8 @@ public struct Gas: Codable {
 }
 
 public struct Neo: Codable {
-    var balance: Double
-    var unspent: [Unspent]
+    public var balance: Double
+    public var unspent: [Unspent]
     
     enum CodingKeys: String, CodingKey {
         case balance = "balance"
@@ -79,10 +79,10 @@ public struct Neo: Codable {
 }
 
 public struct Assets: Codable {
-    var gas: Gas
-    var neo: Neo
-    var address: String
-    var net: String
+    public var gas: Gas
+    public var neo: Neo
+    public var address: String
+    public var net: String
     
     enum CodingKeys: String, CodingKey {
         case gas = "GAS"

--- a/NeoSwift/Models/Block.swift
+++ b/NeoSwift/Models/Block.swift
@@ -9,19 +9,19 @@
 import Foundation
 
 public struct Block: Codable {
-    var confirmations: Int64
-    var hash: String
-    var index: Int64
-    var merkleRoot: String
-    var nextBlockHash: String
-    var nextConsensus: String
-    var nonce: String
-    var previousBlockHash: String
-    var size: Int64
-    var time: Int64
-    var version: Int64
-    var script: Script
-    var transactions: [Transaction] 
+    public var confirmations: Int64
+    public var hash: String
+    public var index: Int64
+    public var merkleRoot: String
+    public var nextBlockHash: String
+    public var nextConsensus: String
+    public var nonce: String
+    public var previousBlockHash: String
+    public var size: Int64
+    public var time: Int64
+    public var version: Int64
+    public var script: Script
+    public var transactions: [Transaction] 
     
     enum CodingKeys : String, CodingKey {
         case confirmations = "confirmations"

--- a/NeoSwift/Models/Script.swift
+++ b/NeoSwift/Models/Script.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct Script: Codable {
-    var invocation: String
-    var verification: String
+    public var invocation: String
+    public var verification: String
     
     enum CodingKeys: String, CodingKey {
         case invocation = "invocation"

--- a/NeoSwift/Models/Transaction.swift
+++ b/NeoSwift/Models/Transaction.swift
@@ -9,16 +9,16 @@
 import Foundation
 
 public struct Transaction: Codable {
-    var transactionID: String
-    var size: Int64
-    var type: String
-    var version: Int64
+    public var transactionID: String
+    public var size: Int64
+    public var type: String
+    public var version: Int64
    // var attributes: [] //Need to handle this, not really sure what kind of objects it can give bakc
-    var valueIns: [ValueIn]
-    var valueOuts: [ValueOut]
-    var systemFee: String
-    var networkFee: String
-    var scripts: [Script]
+    public var valueIns: [ValueIn]
+    public var valueOuts: [ValueOut]
+    public var systemFee: String
+    public var networkFee: String
+    public var scripts: [Script]
    // var nonce: Int64
     
     //TODO: FIGURE OUT THE ATTRIBUTES

--- a/NeoSwift/Models/ValueIn.swift
+++ b/NeoSwift/Models/ValueIn.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 public struct ValueIn: Codable {
-    var transactionID: String
-    var valueOut: Int
+    public var transactionID: String
+    public var valueOut: Int
     
     enum CodingKeys: String, CodingKey {
         case transactionID = "txid"

--- a/NeoSwift/Models/ValueOut.swift
+++ b/NeoSwift/Models/ValueOut.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 public struct ValueOut: Codable {
-    var n: Int
-    var asset: String
-    var value: String
-    var address: String
+    public var n: Int
+    public var asset: String
+    public var value: String
+    public var address: String
     
     enum CodingKeys: String, CodingKey {
         case n = "n" // need clarification on this value better naming over all would be good

--- a/NeoSwift/NeoClient.swift
+++ b/NeoSwift/NeoClient.swift
@@ -36,7 +36,7 @@ public enum NeoClientResult<T> {
 
 public class NeoClient {
     public var seed = "http://seed4.neo.org:20332"
-    public var fullNodeAPI = "http://testnet-api.wallet.cityofzion.io/v1/"
+    public var fullNodeAPI = "http://testnet-api.wallet.cityofzion.io/v2/"
     public static let shared = NeoClient()
     private init() {}
     
@@ -59,7 +59,7 @@ public class NeoClient {
     }
     
     enum apiURL: String {
-        case getBalance = "http://testnet-api.wallet.cityofzion.io/v1/address/balance/"
+        case getBalance = "http://testnet-api.wallet.cityofzion.io/v2/address/balance/"
         case getTransactionHistory = "http://testnet-api.neonwallet.com/v2/address/history/"
     }
     
@@ -331,7 +331,7 @@ public class NeoClient {
     }
     
     public func sendRawTransaction(with data: Data, completion: @escaping(NeoClientResult<Bool>) -> ()) {
-        sendRequest(.sendTransaction, params: [data.hexEncodedString()]) { result in
+        sendRequest(.sendTransaction, params: [data.fullHexString]) { result in
             switch result {
             case .failure(let error):
                 completion(.failure(error))

--- a/NeoSwift/Util/Base58.swift
+++ b/NeoSwift/Util/Base58.swift
@@ -1,0 +1,133 @@
+//
+//  Base58.swift
+//  NeoSwift
+//
+//  Created by Luís Silva on 11/09/17.
+//  Copyright © 2017 drei. All rights reserved.
+//
+
+import Foundation
+
+let base58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+extension Array where Element == UInt8 {
+    public var base58String: String? {
+        guard !self.isEmpty else { return nil }
+        
+        var bytes = self
+        
+        var zerosCount = 0
+        var length = 0
+        
+        for b in bytes {
+            if b != 0 { break }
+            zerosCount += 1
+        }
+        
+        bytes.removeFirst(zerosCount)
+        
+        let size = bytes.count * 138 / 100 + 1
+        
+        var base58: [UInt8] = Array(repeating: 0, count: size)
+        for b in bytes {
+            var carry = Int(b)
+            var i = 0
+            
+            for j in 0...base58.count-1 where carry != 0 || i < length {
+                carry += 256 * Int(base58[base58.count - j - 1])
+                base58[base58.count - j - 1] = UInt8(carry % 58)
+                carry /= 58
+                i += 1
+            }
+            
+            assert(carry == 0)
+            length = i
+        }
+        
+        // skip leading zeros
+        var zerosToRemove = 0
+        var str = ""
+        for b in base58 {
+            if b != 0 { break }
+            zerosToRemove += 1
+        }
+        base58.removeFirst(zerosToRemove)
+        
+        while 0 < zerosCount {
+            str = "\(str)1"
+            zerosCount -= 1
+        }
+        
+        for b in base58 {
+            str = "\(str)\(base58Alphabet[String.Index(encodedOffset: Int(b))])"
+        }
+        
+        return str
+    }
+}
+
+extension String {
+    public var base58String: String? {
+        return [UInt8](utf8).base58String
+    }
+    
+    public var fromBase58: Data? {
+        guard let array = self.arrayFromBase58 else { return nil }
+        return Data(array)
+    }
+    
+    public var arrayFromBase58: [UInt8]? {
+        // remove leading and trailing whitespaces
+        var string = self.trimmingCharacters(in: CharacterSet.whitespaces)
+        
+        guard !string.isEmpty else { return nil }
+        
+        var zerosCount = 0
+        var length = 0
+        for c in string.characters {
+            if c != "1" { break }
+            zerosCount += 1
+        }
+        
+        let size = string.lengthOfBytes(using: String.Encoding.utf8) * 733 / 1000 + 1 - zerosCount
+        var base58: [UInt8] = Array(repeating: 0, count: size)
+        for c in string.characters where c != " " {
+            // search for base58 character
+            guard let base58Index = base58Alphabet.index(of: c) else { return nil }
+            
+            var carry = base58Index.encodedOffset
+            var i = 0
+            for j in 0...base58.count where carry != 0 || i < length {
+                carry += 58 * Int(base58[base58.count - j - 1])
+                base58[base58.count - j - 1] = UInt8(carry % 256)
+                carry /= 256
+                i += 1
+            }
+            
+            assert(carry == 0)
+            length = i
+        }
+        
+        // skip leading zeros
+        var zerosToRemove = 0
+        
+        for b in base58 {
+            if b != 0 { break }
+            zerosToRemove += 1
+        }
+        base58.removeFirst(zerosToRemove)
+        
+        var result: [UInt8] = Array(repeating: 0, count: zerosCount + base58.count)
+        while 0 < zerosCount {
+            result[zerosCount] = 0
+            zerosCount -= 1
+        }
+        
+        var i = 0
+        for b in base58 {
+            result[i] = b
+            i += 1
+        }
+        return result
+    }
+}

--- a/NeoSwift/Util/Data+Util.swift
+++ b/NeoSwift/Util/Data+Util.swift
@@ -1,0 +1,36 @@
+//
+//  Data+Util.swift
+//  NeoSwift
+//
+//  Created by Luís Silva on 13/09/17.
+//  Copyright © 2017 drei. All rights reserved.
+//
+
+import Foundation
+
+extension Data {
+    
+    // MARK: Hex String
+    
+    public var hexString: String {
+        return self.map { return String(format: "%x", $0) }.joined()
+    }
+    
+    public var hexStringWithPrefix: String {
+        return "0x\(hexString)"
+    }
+    
+    public var fullHexString: String {
+        return self.map { return String(format: "%02x", $0) }.joined()
+    }
+    
+    public var fullHexStringWithPrefix: String {
+        return "0x\(fullHexString)"
+    }
+    
+    // MARK: Data to [UInt8]
+    
+    public var bytes: [UInt8] {
+        return [UInt8](self)
+    }
+}

--- a/NeoSwift/Util/SHA256.swift
+++ b/NeoSwift/Util/SHA256.swift
@@ -1,0 +1,34 @@
+//
+//  SHA256.swift
+//  NeoSwift
+//
+//  Created by Luís Silva on 13/09/17.
+//  Copyright © 2017 drei. All rights reserved.
+//
+
+import Foundation
+import CommonCrypto
+
+extension Data {
+    public var sha256: Data {
+        let bytes = [UInt8](self)
+        
+        let mutablePointer = UnsafeMutablePointer<UInt8>.allocate(capacity: Int(CC_SHA256_DIGEST_LENGTH))
+        
+        CC_SHA256(bytes, CC_LONG(bytes.count), mutablePointer)
+
+        let mutableBufferPointer = UnsafeMutableBufferPointer<UInt8>.init(start: mutablePointer, count: Int(CC_SHA256_DIGEST_LENGTH))
+        let sha256Data = Data(buffer: mutableBufferPointer)
+        
+        mutablePointer.deallocate(capacity: Int(CC_SHA256_DIGEST_LENGTH))
+        
+        return sha256Data
+    }
+}
+
+extension String {
+    public var sha256: Data? {
+        return self.data(using: String.Encoding.utf8)?.sha256
+    }
+    
+}

--- a/NeoSwift/WIF.swift
+++ b/NeoSwift/WIF.swift
@@ -7,20 +7,18 @@
 //
 
 import Foundation
-import SwiftBaseX
-import CryptoSwift
     
 public extension String {
     func hashFromAddress() -> String {
-        let decoded = try! self.decodeBase58()
+        let decoded = self.fromBase58!
         let bytes  = [UInt8](decoded)
         let shortened = bytes[0...20] //need exactly twenty one bytes
         let substringData = Data(bytes: shortened)
-        let hashOne = substringData.sha256()
-        let hashTwo = hashOne.sha256()
+        let hashOne = substringData.sha256
+        let hashTwo = hashOne.sha256
         let bytesTwo = [UInt8](hashTwo)
         let finalKeyData = Data(bytes: shortened[1...shortened.count - 1])
-        return finalKeyData.fullHexEncodedString()
+        return finalKeyData.fullHexString
     }
     
     func dataWithHexString() -> Data {

--- a/NeoSwiftTests/NeoCryptoTests.swift
+++ b/NeoSwiftTests/NeoCryptoTests.swift
@@ -1,0 +1,49 @@
+//
+//  NeoCryptoTests.swift
+//  NeoSwiftTests
+//
+//  Created by Luís Silva on 16/09/17.
+//  Copyright © 2017 drei. All rights reserved.
+//
+
+import XCTest
+
+class NeoCryptoTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    // MARK: - Base58
+    
+    func testBase58Encoding() {
+        XCTAssertNil([].base58String)
+        
+        XCTAssert("derp".base58String == "3ZqqXd")
+        XCTAssert("1".base58String == "r")
+        XCTAssert("the quick brown fox".base58String == "NK2qR8Vz63NeeAJp9XRifbwahu")
+        XCTAssert("THE QUICK BROWN FOX".base58String == "GRvKwF9B69ssT67JgRWxPQTZ2X")
+        
+    }
+    
+    func testBase58Decoding() {
+        XCTAssertNil("".fromBase58)
+        
+        XCTAssert(String(data: "3ZqqXd".fromBase58!, encoding: .utf8) == "derp")
+        XCTAssert(String(data: "r".fromBase58!, encoding: .utf8) == "1")
+        XCTAssert(String(data: "NK2qR8Vz63NeeAJp9XRifbwahu".fromBase58!, encoding: .utf8) == "the quick brown fox")
+        XCTAssert( String(data: "GRvKwF9B69ssT67JgRWxPQTZ2X".fromBase58!, encoding: .utf8) == "THE QUICK BROWN FOX")
+    }
+    
+    // MARK: - SHA256
+    
+    func testSHA256() {
+        XCTAssert("".sha256?.fullHexString == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        XCTAssert("NEO".sha256?.fullHexString == "1a259dba256600620c6c91094f3a300b30f0cbaecee19c6114deffd3288957d7")
+        XCTAssert("Smart Economy".sha256?.fullHexString == "6c4cb281896c7779f4e2800471638026d52178b2556a0a3fbc3673368ba97385")
+    }
+}


### PR DESCRIPTION
Removes SwiftBaseX and CryptoSwift dependencies (Base58 algorithm implemented in Swift, SHA256 algorithm using CommonCrypto);
Fixes some minor things (changed to new NEO API endpoint);
Sets to Public properties that had no scope set since they are by default Internal;
Adds .gitignore for Xcode and Swift;
Also, removed Carthage dependency since it is no longer required;

**What current issue(s) from Github does this address?**
Dependencies of SwiftBaseX, CryptoSwift.
Internal properties in models.
Missing .gitignore.

**What problem does this PR solve?**
Removes dependencies of SwiftBaseX, CryptoSwift.
Sets to public properties without scoping.

**How did you solve this problem?**
For SHA256 I used CommonCrypto which is included in iOS.
For Base58 I implemented the encoding/decoding algorithm in Swift.
I also created some util properties to generate hex strings and such.

**How did you make sure your solution works?**
Run the tests, including tests I created and also tested against know Base58 encodings and SHA256 digests.

**Are there any special changes in the code that we should be aware of?**
Not in the code itself, but for SHA256 I used CommonCrypto, and for it to be used in Swift I had to create a modulemap (it's inside CommonCrypto/) and add it's directory path to Import Paths in the settings.

**Is there anything else we should know?**

- [1 ] Unit tests written?
NeoCryptoTests (SHA256, Base58)