### PR TITLE
Add Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: objective-c
+osx_image: xcode9.1
+
+xcode_project: NeoSwift.xcodeproj
+xcode_scheme: NeoSwift
+xcode_sdk: iphonesimulator11.1
+
+script:
+  - xcodebuild clean build test -project NeoSwift.xcodeproj -scheme NeoSwift -destination 'platform=iOS Simulator,name=iPhone 8 Plus,OS=11.1'

--- a/NeoSwift/NeoClient.swift
+++ b/NeoSwift/NeoClient.swift
@@ -336,7 +336,7 @@ public class NeoClient {
     }
     
     //NEED TO GUARD ON THE VALUE OUTS
-    public func getTransactionOutput(with hash: String, and index: Int64, completion: @escaping (NeoClientResult<ValueOut>) -> ()) {
+    public func getTransactionOutput(with hash: String, and index: Int64, completion: @escaping (NeoClientResult<[ValueOut]>) -> ()) {
         sendRequest(.getTransaction, params: [hash, index]) { result in
             switch result {
             case .failure(let error):
@@ -344,12 +344,12 @@ public class NeoClient {
             case .success(let response):
                 let decoder = JSONDecoder()
                 guard let data = try? JSONSerialization.data(withJSONObject: (response["result"] as! JSONDictionary), options: .prettyPrinted),
-                    let block = try? decoder.decode(ValueOut.self, from: data) else {
+                    let block = try? decoder.decode(Transaction.self, from: data) else {
                         completion(.failure(.invalidData))
                         return
                 }
                 
-                let result = NeoClientResult.success(block)
+                let result = NeoClientResult.success(block.valueOuts)
                 completion(result)
             }
         }

--- a/NeoSwiftTests/NeoSwiftTests.swift
+++ b/NeoSwiftTests/NeoSwiftTests.swift
@@ -141,8 +141,8 @@ class NeoSwiftTests: XCTestCase {
     func testTransactionOutput() {
         let exp = expectation(description: "Wait for block hash response")
         
-        let hash = "2288ba9bd93da4ac4c414048f019300c8adadc6df5e4bfeb6fc79da7f955e638"
-        let index: Int64 = 0
+        let hash = "469fe36c464442aa3eecc377f2093ad8594d0e764aad5e4aab5120ed4f3683fc"
+        let index: Int64 = 1
         NeoClient.sharedTest.getTransactionOutput(with: hash, and: index) { result in
             switch result {
             case .failure:
@@ -219,6 +219,7 @@ class NeoSwiftTests: XCTestCase {
             assert(success ?? false)
             print(success)
             exp1.fulfill()
+            sleep(10)
             accountB.sendAssetTransaction(asset: .neoAssetId, amount: 1, toAddress: accountA.address) {success, error in
                 assert(success ?? false)
                 exp2.fulfill()
@@ -362,14 +363,14 @@ class NeoSwiftTests: XCTestCase {
     }
     
     func testOverwriteSeedNode(){
-        let client = NeoClient(network: .main, seedURL: (NEONetworkMonitor.sharedInstance.network?.mainNet.nodes[0].URL)!)
-        assert(client.seed == "http://seed2.neo.org:10332")
+        let client = NeoClient(network: .main, seedURL: (NEONetworkMonitor.sharedInstance.network?.mainNet.nodes[9].URL)!)
+        XCTAssertEqual(client.seed, "http://seed5.cityofzion.io:8080")
     }
     
     func testGetPeers() {
         let exp = expectation(description: "Wait for GetPeers Response")
         
-        let client = NeoClient(network: .main, seedURL: (NEONetworkMonitor.sharedInstance.network?.mainNet.nodes[0].URL)!)
+        let client = NeoClient(network: .main, seedURL: (NEONetworkMonitor.sharedInstance.network?.mainNet.nodes[9].URL)!)
         client.getPeers { result in
             switch result {
             case .failure:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
   Swift SDK for the <b>NEO</b> blockchain.
 </p>
 
+[![Build Status](https://travis-ci.org/CityOfZion/neo-swift.svg?branch=master)](https://travis-ci.org/CityOfZion/neo-swift)
+
 ## What is neo-swift
 
 - A swift client for interacting with a node on the [NEO](http://neo.org/) blockchain.


### PR DESCRIPTION
**What current issue(s) from Github does this address?**

No

**What problem does this PR solve?**

Add CI support for neo-swift to be a robust open-source project.

**How did you solve this problem?**

Fix existing failing test cases and add TravisCI config file.

**How did you make sure your solution works?**

It works fine on my fork https://travis-ci.org/zjhmale/neo-swift/builds/297495365.

**Are there any special changes in the code that we should be aware of?**

Some existing test cases will fail so I made some changes to the `NeoSwiftTests` file.

**Is there anything else we should know?**

The test case `testGetPeers` does not always work as expected because sometimes you will get 

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -2147467261,
        "message": "Object reference not set to an instance of an object.",
        "data": "   at Neo.Network.RPC.RpcServer.Process(String method, JArray _params) in C:\\Users\\me\\NEO\\neo\\neo\\Network\\RPC\\RpcServer.cs:line 283\n   at Neo.Network.RPC.RpcServerWithWallet.Process(String method, JArray _params)\n   at Neo.Network.RPC.RpcServer.ProcessRequest(JObject request) in C:\\Users\\me\\NEO\\neo\\neo\\Network\\RPC\\RpcServer.cs:line 371"
    }
}
```

when you send a `getpeers` RPC request to a concrete NEO node, and the node which works fine today maybe will return the error tomorrow which is quite annoying and unpredictable, this issue is out of my hand so maybe members of CoZ can address it properly.

- [x] Unit tests written?
